### PR TITLE
fix: ID sent by Publisher as integer

### DIFF
--- a/lib/SQSEventEmitterMQ.js
+++ b/lib/SQSEventEmitterMQ.js
@@ -15,7 +15,7 @@ class Publisher {
       payload = message.map((body, index) => Object.assign({ id: index.toString(), body }, channel
         ? { groupId: channel } : {}));
     } else {
-      payload = Object.assign({ id: 0, body: message }, channel ? { groupId: channel } : {});
+      payload = Object.assign({ id: '0', body: message }, channel ? { groupId: channel } : {});
     }
 
     this.emitter.send(payload, (err) => {


### PR DESCRIPTION
The ID field should be sent as a string. AWS SDK doesn't recognizes it and throws the following error: "Missing required key 'Id' in params.Entries[0]".