### PR TITLE
ci: Fix auto release

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: 24
+          node-version: 22
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Auto release workflow tries to download Node 24 which doesn't exist yet