### PR TITLE
ci: Fix auto-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/parse-server-modules/parse-server-sqs-mq-adapter.git"
+    "url": "git+https://github.com/parse-community/parse-server-sqs-mq-adapter.git"
   },
   "author": "Parse Platform",
   "license": "Apache-2.0",


### PR DESCRIPTION
The `repository` prop in package.json points to a previous repo name, hence semantic release fails. Updated prop to current repo name.